### PR TITLE
added four new peek commands; updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 *.pyc
 q-*
+
+# build artifacts
+build/
+dist/
+*.egg-info/
+
+# virtualenvs
+venv/
+ve/
+
+# misc
+.DS_Store

--- a/beanstalkd/queueit/__init__.py
+++ b/beanstalkd/queueit/__init__.py
@@ -267,6 +267,32 @@ def qwrapper(tube_in, tube_out, worker_cmd):
             job.delete()
 
 
+def qpeeknext(qname, peek_type):
+    '''
+    peeks at the next job in a tube
+    '''
+    qconn  = _get_qconnection(QHOST, QPORT)
+    print "Peeking at next %s job in queue" % peek_type, qconn.use(qname)
+    job = getattr(qconn, 'peek_%s' % peek_type)()
+    if not job:
+        print 'No %s jobs in %s' % (peek_type, qname)
+        return
+    print job.jid, job.body
+
+
+def qpeekjob(jid):
+    '''
+    peeks at the next job in a tube
+    '''
+    qconn  = _get_qconnection(QHOST, QPORT)
+    print "Peeking at job_id %s" % jid
+    job = qconn.peek(int(jid))
+    if not job:
+        print 'Job %s not found' % jid
+        return
+    print job.jid, job.body
+
+
 def main():
     try:
         COMMAND = os.path.basename(sys.argv[0])
@@ -281,6 +307,10 @@ def main():
                 print "%s q-wrapper" % COMMAND
                 print "%s q-wrapper-batch" % COMMAND
                 print "%s q-wrapper-with-stats" % COMMAND
+                print "%s q-peek" % COMMAND
+                print "%s q-peek-ready" % COMMAND
+                print "%s q-peek-delayed" % COMMAND
+                print "%s q-peek-buried" % COMMAND
                 sys.exit(1)
             else:
                 COMMAND = os.path.basename(sys.argv[1])
@@ -338,6 +368,30 @@ def main():
         elif COMMAND == 'q-cleanup':
             if len(args) == 1:
                 qcleanup(args[0])
+            else:
+                print "Usage: %s <queue>" % (COMMAND)
+                print sys.exit(1)
+        elif COMMAND == 'q-peek':
+            if len(args) == 1:
+                qpeekjob(args[0])
+            else:
+                print "Usage: %s <job_id>" % (COMMAND)
+                print sys.exit(1)
+        elif COMMAND == 'q-peek-ready':
+            if len(args) == 1:
+                qpeeknext(args[0], peek_type="ready")
+            else:
+                print "Usage: %s <queue>" % (COMMAND)
+                print sys.exit(1)
+        elif COMMAND == 'q-peek-delayed':
+            if len(args) == 1:
+                qpeeknext(args[0], peek_type="delayed")
+            else:
+                print "Usage: %s <queue>" % (COMMAND)
+                print sys.exit(1)
+        elif COMMAND == 'q-peek-buried':
+            if len(args) == 1:
+                qpeeknext(args[0], peek_type="buried")
             else:
                 print "Usage: %s <queue>" % (COMMAND)
                 print sys.exit(1)

--- a/beanstalkd/setup.py
+++ b/beanstalkd/setup.py
@@ -2,13 +2,17 @@ from setuptools import setup
 
 setup(
     name="queueit",
-    version="1.0",
+    version="1.1",
     author="Anton P. Linevich",
 
     packages=['queueit'],
 
     entry_points={
         'console_scripts': [
+            'q-peek = queueit:main',
+            'q-peek-ready = queueit:main',
+            'q-peek-delayed = queueit:main',
+            'q-peek-buried = queueit:main',
             'q-get = queueit:main',
             'q-kick = queueit:main',
             'q-put = queueit:main',


### PR DESCRIPTION
New commands!
* ```q-peek <job_id>```
  * shows the job body for the job with id <job_id>
* ```q-peek-ready <queue_name>```
* ```q-peek-delayed <queue_name>```
* ```q-peek-buried <queue_name>```
  shows the job body of the next job available from that tube
  on ```<queue_name>``` - eg, ```q-peek-ready myqueue``` shows the next job available
  in the ```ready``` tube on queue ```myqueue```

gitignore additions:
* added a few common exclusions (build artifacts, common python virtualenv directory names)