### PR TITLE
Enabled q-cleanup and added ability to clean ready, delayed, buried peek types. Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ ve/
 
 # misc
 .DS_Store
+
+.idea/

--- a/beanstalkd/setup.py
+++ b/beanstalkd/setup.py
@@ -17,7 +17,8 @@ setup(
             'q-kick = queueit:main',
             'q-put = queueit:main',
             'q-stat = queueit:main',
-            'q-wrapper = queueit:main'
+            'q-wrapper = queueit:main',
+            'q-cleanup = queueit:main'
         ]
     }
 )


### PR DESCRIPTION
Now we can use: `q-cleanup <queue> <peek_type>`
Examples: `q-cleanup default buried`, `q-cleanup default ready`, etc 
